### PR TITLE
Add unit tests

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -75,3 +75,63 @@ pub struct LoggingConfig {
     pub level: String,
     pub file: Option<PathBuf>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const CONFIG_V1: &str = r#"
+        [relayer]
+        mnemonic = "mnemonic1"
+
+        [database]
+        path = "/tmp/db1.sqlite"
+
+        [logging]
+        level = "info"
+        file = "/tmp/log1.log"
+
+        [strategies.path-finder]
+        vault = "0x0000000000000000000000000000000000000000"
+        contract = "0x00"
+        max_profit_ratio = "0.005"
+        min_profit_ratio = "0.001"
+    "#;
+
+    const CONFIG_V2: &str = r#"
+        [relayer]
+        mnemonic = "mnemonic2"
+
+        [database]
+        path = "/tmp/db2.sqlite"
+
+        [logging]
+        level = "debug"
+        file = "/tmp/log2.log"
+
+        [strategies.path-finder]
+        vault = "0x0000000000000000000000000000000000000001"
+        contract = "0x01"
+        max_profit_ratio = "0.010"
+        min_profit_ratio = "0.002"
+    "#;
+
+    #[test]
+    fn test_from_file_and_reload() {
+        let path = std::env::temp_dir().join("searcher_config_test.toml");
+        fs::write(&path, CONFIG_V1).unwrap();
+
+        let mut cfg = SearcherConfig::from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(cfg.relayer.mnemonic, "mnemonic1");
+        assert_eq!(cfg.logging.level, "info");
+
+        fs::write(&path, CONFIG_V2).unwrap();
+        cfg.reload(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(cfg.relayer.mnemonic, "mnemonic2");
+        assert_eq!(cfg.logging.level, "debug");
+
+        let _ = fs::remove_file(&path);
+    }
+}

--- a/crates/config/src/strategy.rs
+++ b/crates/config/src/strategy.rs
@@ -73,3 +73,30 @@ pub struct PathFinderConfig {
 }
 
 // TODO: Add other strategy configurations
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_common_strategy_functions() {
+        let cfg = PathFinderConfig {
+            vault: "0x0000000000000000000000000000000000000000".to_string(),
+            contract: "00".to_string(),
+            max_profit_ratio: "0.005".to_string(),
+            min_profit_ratio: "0.001".to_string(),
+        };
+        let strategy = StrategyConfig::PathFinder(cfg.clone());
+
+        assert_eq!(strategy.get_exex_id(), PATH_FINDER_EXEX_ID);
+        assert_eq!(strategy.get_vault(), cfg.vault.parse().unwrap());
+
+        let (max, min) = strategy.get_profit_ratios();
+        let expected_max = ((0.005_f64 * 1_000_000.0) as u128 * 1_000_000_000_000_000_000u128)
+            / 1_000_000u128;
+        let expected_min = ((0.001_f64 * 1_000_000.0) as u128 * 1_000_000_000_000_000_000u128)
+            / 1_000_000u128;
+        assert_eq!(max, U256::from(expected_max));
+        assert_eq!(min, U256::from(expected_min));
+    }
+}

--- a/crates/util/src/logger.rs
+++ b/crates/util/src/logger.rs
@@ -52,3 +52,21 @@ fn get_log_dir() -> String {
         .map(|home| format!("{}/logs", home))
         .unwrap_or_else(|_| "./logs".to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::get_log_dir;
+
+    #[test]
+    fn returns_log_dir_from_env() {
+        std::env::set_var("LOG_DIR", "/tmp/test_logs");
+        assert_eq!(get_log_dir(), "/tmp/test_logs");
+        std::env::remove_var("LOG_DIR");
+    }
+
+    #[test]
+    fn returns_default_log_dir_in_debug() {
+        std::env::remove_var("LOG_DIR");
+        assert_eq!(get_log_dir(), "./logs");
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for logger's log directory helper
- cover config file loading and reloading
- test strategy configuration helpers

## Testing
- `cargo test --workspace` *(fails: Failed to fetch crates due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685ac17e1dd883268c94741b14ac0dba