### PR TITLE
refactor: remove unused dex and token tables

### DIFF
--- a/crates/repository/src/model.rs
+++ b/crates/repository/src/model.rs
@@ -1,24 +1,6 @@
 use crate::schema::*;
 use diesel::prelude::*;
 
-#[derive(Debug, Clone, Queryable, Identifiable)]
-#[diesel(primary_key(chain_id, address, priority))]
-#[diesel(table_name = token)]
-pub struct Token {
-    pub chain_id: i32,
-    pub address: String,
-    pub priority: i32,
-}
-
-#[derive(Debug, Clone, Queryable, Identifiable)]
-#[diesel(primary_key(chain_id, address, dex_type))]
-#[diesel(table_name = dex)]
-pub struct Dex {
-    pub chain_id: i32,
-    pub address: String,
-    pub dex_type: i32,
-}
-
 #[repr(i32)]
 #[derive(Debug, Clone, Copy)]
 pub enum HopType {

--- a/crates/repository/src/schema.rs
+++ b/crates/repository/src/schema.rs
@@ -1,14 +1,6 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    dex (chain_id, address, dex_type) {
-        chain_id -> Integer,
-        address -> Text,
-        dex_type -> Integer,
-    }
-}
-
-diesel::table! {
     hop (chain_id, address, dex_type, src_token, dst_token) {
         chain_id -> Integer,
         address -> Text,
@@ -20,12 +12,4 @@ diesel::table! {
     }
 }
 
-diesel::table! {
-    token (chain_id, address, priority) {
-        chain_id -> Integer,
-        address -> Text,
-        priority -> Integer,
-    }
-}
-
-diesel::allow_tables_to_appear_in_same_query!(dex, hop, token);
+diesel::allow_tables_to_appear_in_same_query!(hop,);


### PR DESCRIPTION
- Remove Token model and schema
- Remove Dex model and schema
- Update diesel allow_tables_to_appear_in_same_query

Part of #8

🤖 Generated with [Claude Code](https://claude.ai/code)