### PR TITLE
Implement balance optimization with ternary search

### DIFF
--- a/crates/config/src/manager.rs
+++ b/crates/config/src/manager.rs
@@ -12,7 +12,7 @@ use alloy_signer_local::{ coins_bip39::English, MnemonicBuilder };
 use eyre::{ eyre, Result };
 use serde::{ Deserialize, Serialize };
 
-use crate::{ strategy::StrategyConfig, types::{ Candidate, Route, RoutesMap } };
+use crate::{ strategy::StrategyConfig, types::{ Candidate, Route, RouteElement, RoutesMap } };
 
 pub struct ConfigManager {
     // configuration from the file
@@ -135,10 +135,10 @@ impl DataConfig {
     }
 
     fn build_all_paths(&self, chain_routes: &Route) -> eyre::Result<Vec<Candidate>> {
-        let token_map: HashMap<_, _> = chain_routes.elements
+        let token_map: HashMap<&String, Vec<&RouteElement>> = chain_routes.elements
             .iter()
             .fold(HashMap::new(), |mut acc, element| {
-                acc.entry(&element.src_token).or_insert_with(Vec::new).push(element);
+                acc.entry(&element.src_token).or_default().push(element);
                 acc
             });
 
@@ -204,25 +204,6 @@ mod tests {
         min_profit_ratio = "0.001"
     "#;
 
-    const CONFIG_V2: &str =
-        r#"
-        [relayer]
-        mnemonic = "mnemonic2"
-
-        [data]
-        path = "/tmp/db2.json"
-
-        [logging]
-        level = "debug"
-        file = "/tmp/log2.log"
-
-        [strategy]
-        [path-finder]
-        vault = "0x0000000000000000000000000000000000000001"
-        contract = "0x01"
-        max_profit_ratio = "0.010"
-        min_profit_ratio = "0.002"
-    "#;
 
     #[test]
     fn test_from_file_and_reload() {

--- a/crates/config/src/strategy.rs
+++ b/crates/config/src/strategy.rs
@@ -1,13 +1,14 @@
-use alloy_primitives::{ Address, Bytes, U256 };
+use alloy_primitives::{Address, Bytes, U256};
 use reth_revm::state::Bytecode;
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 
 // Strategy configuration
 pub const PATH_FINDER_EXEX_ID: &str = "path-finder";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
 pub enum StrategyConfig {
-    #[serde(rename = "path-finder")] PathFinder(PathFinderConfig),
+    #[serde(rename = "path-finder")]
+    PathFinder(PathFinderConfig),
     // #[serde(rename = "liquidation")] Liquidation(LiquidationConfig),
     // #[serde(rename = "arbitrage")] Arbitrage(ArbitrageConfig),
 }
@@ -32,12 +33,10 @@ impl CommonStrategyConfig for StrategyConfig {
 
     fn get_liquidity_range(&self) -> (U256, U256) {
         match self {
-            StrategyConfig::PathFinder(config) => {
-                (
-                    U256::from(config.min_liquidity.parse::<u128>().unwrap() * ONE_ETHER),
-                    U256::from(config.max_liquidity.parse::<u128>().unwrap() * ONE_ETHER),
-                )
-            }
+            StrategyConfig::PathFinder(config) => (
+                U256::from(config.min_liquidity.parse::<u128>().unwrap() * ONE_ETHER),
+                U256::from(config.max_liquidity.parse::<u128>().unwrap() * ONE_ETHER),
+            ),
         }
     }
 
@@ -58,19 +57,18 @@ impl CommonStrategyConfig for StrategyConfig {
 
     fn get_profit_ratios(&self) -> (U256, U256) {
         match self {
-            StrategyConfig::PathFinder(config) =>
-                (
-                    U256::from(
-                        (((config.max_profit_ratio.parse::<f64>().unwrap() * 1_000_000.0) as u128) *
-                            ONE_ETHER) /
-                            1_000_000
-                    ),
-                    U256::from(
-                        (((config.min_profit_ratio.parse::<f64>().unwrap() * 1_000_000.0) as u128) *
-                            ONE_ETHER) /
-                            1_000_000
-                    ),
+            StrategyConfig::PathFinder(config) => (
+                U256::from(
+                    (((config.max_profit_ratio.parse::<f64>().unwrap() * 1_000_000.0) as u128)
+                        * ONE_ETHER)
+                        / 1_000_000,
                 ),
+                U256::from(
+                    (((config.min_profit_ratio.parse::<f64>().unwrap() * 1_000_000.0) as u128)
+                        * ONE_ETHER)
+                        / 1_000_000,
+                ),
+            ),
         }
     }
 }
@@ -103,7 +101,7 @@ mod tests {
             vault: "0x0000000000000000000000000000000000000000".to_string(),
             contract: "00".to_string(),
             max_liquidity: "1000".to_string(), // 1000 USDC
-            min_liquidity: "100".to_string(), // 100 USDC
+            min_liquidity: "100".to_string(),  // 100 USDC
             max_profit_ratio: "0.005".to_string(),
             min_profit_ratio: "0.001".to_string(),
         };
@@ -113,10 +111,8 @@ mod tests {
         assert_eq!(strategy.get_vault(), cfg.vault.parse::<Address>().unwrap());
 
         let (max, min) = strategy.get_profit_ratios();
-        let expected_max =
-            (((0.005_f64 * 1_000_000.0) as u128) * ONE_ETHER) / 1_000_000u128;
-        let expected_min =
-            (((0.001_f64 * 1_000_000.0) as u128) * ONE_ETHER) / 1_000_000u128;
+        let expected_max = (((0.005_f64 * 1_000_000.0) as u128) * ONE_ETHER) / 1_000_000u128;
+        let expected_min = (((0.001_f64 * 1_000_000.0) as u128) * ONE_ETHER) / 1_000_000u128;
         assert_eq!(max, U256::from(expected_max));
         assert_eq!(min, U256::from(expected_min));
 
@@ -124,13 +120,7 @@ mod tests {
         let expected_max_liquidity = U256::from(1000 * ONE_ETHER);
         let expected_min_liquidity = U256::from(100 * ONE_ETHER);
 
-        assert_eq!(
-            min_liquidity,
-            expected_min_liquidity
-        );
-        assert_eq!(
-            max_liquidity,
-            expected_max_liquidity
-        );
+        assert_eq!(min_liquidity, expected_min_liquidity);
+        assert_eq!(max_liquidity, expected_max_liquidity);
     }
 }

--- a/crates/strategy/src/path_finding/path_finder.rs
+++ b/crates/strategy/src/path_finding/path_finder.rs
@@ -167,12 +167,117 @@ impl<'a, StrategyDatabase> Strategy<'a>
                         }
                     }
 
-                    let balance = Self::search_optimal_balance(
-                        &pevm,
-                        &hops,
-                        min_liquidity,
-                        max_liquidity,
+                    let mut left = min_liquidity;
+                    let mut right = max_liquidity;
+
+                    for _ in 0..MAX_SEARCH_DEPTH {
+                        if right <= left + U256::from(1u8) {
+                            break;
+                        }
+
+                        let diff = right - left;
+                        let one_third = diff / U256::from(3u8);
+                        let mid1 = left + one_third;
+                        let mid2 = right - one_third;
+
+                        let (profit1, profit2) = join(
+                            || {
+                                let encoded = (getProfitCall {
+                                    amount: mid1,
+                                    route: hops.clone(),
+                                })
+                                    .abi_encode();
+                                let mut evm = pevm.lock().unwrap();
+                                let ResultAndState { result, .. } = evm
+                                    .transact_system_call(
+                                        encoded.into(),
+                                        STRATEGY_CONTRACT_ADDRESS,
+                                    )
+                                    .unwrap();
+                                match result {
+                                    ExecutionResult::Success {
+                                        output: Output::Call(value),
+                                        ..
+                                    } => <U256>::abi_decode(&value).unwrap_or_default(),
+                                    _ => U256::ZERO,
+                                }
+                            },
+                            || {
+                                let encoded = (getProfitCall {
+                                    amount: mid2,
+                                    route: hops.clone(),
+                                })
+                                    .abi_encode();
+                                let mut evm = pevm.lock().unwrap();
+                                let ResultAndState { result, .. } = evm
+                                    .transact_system_call(
+                                        encoded.into(),
+                                        STRATEGY_CONTRACT_ADDRESS,
+                                    )
+                                    .unwrap();
+                                match result {
+                                    ExecutionResult::Success {
+                                        output: Output::Call(value),
+                                        ..
+                                    } => <U256>::abi_decode(&value).unwrap_or_default(),
+                                    _ => U256::ZERO,
+                                }
+                            },
+                        );
+
+                        if profit1 < profit2 {
+                            left = mid1;
+                        } else {
+                            right = mid2;
+                        }
+                    }
+
+                    let (profit_left, profit_right) = join(
+                        || {
+                            let encoded = (getProfitCall {
+                                amount: left,
+                                route: hops.clone(),
+                            })
+                                .abi_encode();
+                            let mut evm = pevm.lock().unwrap();
+                            let ResultAndState { result, .. } = evm
+                                .transact_system_call(
+                                    encoded.into(),
+                                    STRATEGY_CONTRACT_ADDRESS,
+                                )
+                                .unwrap();
+                            match result {
+                                ExecutionResult::Success {
+                                    output: Output::Call(value),
+                                    ..
+                                } => <U256>::abi_decode(&value).unwrap_or_default(),
+                                _ => U256::ZERO,
+                            }
+                        },
+                        || {
+                            let encoded = (getProfitCall {
+                                amount: right,
+                                route: hops.clone(),
+                            })
+                                .abi_encode();
+                            let mut evm = pevm.lock().unwrap();
+                            let ResultAndState { result, .. } = evm
+                                .transact_system_call(
+                                    encoded.into(),
+                                    STRATEGY_CONTRACT_ADDRESS,
+                                )
+                                .unwrap();
+                            match result {
+                                ExecutionResult::Success {
+                                    output: Output::Call(value),
+                                    ..
+                                } => <U256>::abi_decode(&value).unwrap_or_default(),
+                                _ => U256::ZERO,
+                            }
+                        },
                     );
+
+                    let balance = if profit_left >= profit_right { left } else { right };
                     if found_max_profit.load(Ordering::Relaxed) {
                         return acc;
                     }
@@ -286,62 +391,3 @@ impl<'a, StrategyDatabase> Strategy<'a>
     }
 }
 
-impl<'a, StrategyDatabase> PathFinder<'a, StrategyDatabase>
-where
-    StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider,
-{
-    fn evaluate_profit(
-        pevm: &Arc<Mutex<PathFinderEvm<'a, StrategyDatabase>>>,
-        hops: &[Hop],
-        amount: U256,
-    ) -> U256 {
-        let encoded = (getProfitCall { amount, route: hops.to_vec() }).abi_encode();
-        let mut evm = pevm.lock().unwrap();
-        let ResultAndState { result, .. } = evm
-            .transact_system_call(encoded.into(), STRATEGY_CONTRACT_ADDRESS)
-            .unwrap();
-        match result {
-            ExecutionResult::Success { output: Output::Call(value), .. } => {
-                <U256>::abi_decode(&value).unwrap_or_default()
-            }
-            _ => U256::ZERO,
-        }
-    }
-
-    fn search_optimal_balance(
-        pevm: &Arc<Mutex<PathFinderEvm<'a, StrategyDatabase>>>,
-        hops: &[Hop],
-        min_liquidity: U256,
-        max_liquidity: U256,
-    ) -> U256 {
-        let mut left = min_liquidity;
-        let mut right = max_liquidity;
-
-        for _ in 0..MAX_SEARCH_DEPTH {
-            if right <= left + U256::from(1u8) {
-                break;
-            }
-
-            let diff = right - left;
-            let one_third = diff / U256::from(3u8);
-            let mid1 = left + one_third;
-            let mid2 = right - one_third;
-
-            let (profit1, profit2) = join(
-                || Self::evaluate_profit(pevm, hops, mid1),
-                || Self::evaluate_profit(pevm, hops, mid2),
-            );
-
-            if profit1 < profit2 {
-                left = mid1;
-            } else {
-                right = mid2;
-            }
-        }
-
-        let profit_left = Self::evaluate_profit(pevm, hops, left);
-        let profit_right = Self::evaluate_profit(pevm, hops, right);
-
-        if profit_left >= profit_right { left } else { right }
-    }
-}

--- a/crates/strategy/src/path_finding/path_finder.rs
+++ b/crates/strategy/src/path_finding/path_finder.rs
@@ -1,63 +1,74 @@
-use std::{ collections::HashMap, sync::{ Arc, Mutex, atomic::{ AtomicBool, Ordering } } };
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
-use alloy_primitives::{ Address, B256, U256, map::HashSet };
-use alloy_rpc_types::{ AccessList, AccessListItem };
-use alloy_sol_types::{ SolCall, SolValue };
-use eyre::{ Error, Ok, Result };
+use alloy_primitives::{Address, B256, U256, map::HashSet};
+use alloy_rpc_types::{AccessList, AccessListItem};
+use alloy_sol_types::{SolCall, SolValue};
+use eyre::{Error, Ok, Result};
 use rayon::{
-    iter::{ IntoParallelRefIterator, ParallelIterator },
+    iter::{IntoParallelRefIterator, ParallelIterator},
     join,
 };
-use reth_provider::{ BlockHashReader, DBProvider, LatestStateProviderRef, StateCommitmentProvider };
+use reth_provider::{BlockHashReader, DBProvider, LatestStateProviderRef, StateCommitmentProvider};
 use reth_revm::{
-    Context,
-    MainBuilder,
-    MainContext,
-    SystemCallEvm,
-    context::{ BlockEnv, CfgEnv, Evm, TxEnv, result::{ ExecutionResult, Output, ResultAndState } },
+    Context, MainBuilder, MainContext, SystemCallEvm,
+    context::{
+        BlockEnv, CfgEnv, Evm, TxEnv,
+        result::{ExecutionResult, Output, ResultAndState},
+    },
     database::StateProviderDatabase,
     db::CacheDB,
-    handler::{ EthPrecompiles, instructions::EthInstructions },
+    handler::{EthPrecompiles, instructions::EthInstructions},
     interpreter::interpreter::EthInterpreter,
-    state::{ AccountInfo, Bytecode },
+    state::{AccountInfo, Bytecode},
 };
 use reth_tracing::tracing;
 use reth_transaction_pool::PoolTransaction;
-use searcher_reth_config::{ strategy::{ CommonStrategyConfig, StrategyConfig }, types::Candidate };
-use searcher_reth_core::strategy::{ STRATEGY_CONTRACT_ADDRESS, Strategy };
+use searcher_reth_config::{
+    strategy::{CommonStrategyConfig, StrategyConfig},
+    types::Candidate,
+};
+use searcher_reth_core::strategy::{STRATEGY_CONTRACT_ADDRESS, Strategy};
 
 use crate::path_finding::types::executeCall;
 
-use super::types::{ Hop, getProfitCall };
+use super::types::{Hop, getProfitCall};
 
 type PathFinderCtx<'a, DB> = Context<
     BlockEnv,
     TxEnv,
     CfgEnv,
-    CacheDB<StateProviderDatabase<LatestStateProviderRef<'a, DB>>>
+    CacheDB<StateProviderDatabase<LatestStateProviderRef<'a, DB>>>,
 >;
 
 type PathFinderEvm<'a, DB> = Evm<
     PathFinderCtx<'a, DB>,
     (),
     EthInstructions<EthInterpreter, PathFinderCtx<'a, DB>>,
-    EthPrecompiles
+    EthPrecompiles,
 >;
 
 const PROFITABLE_PATHS_LIMIT: usize = 10;
 const MAX_SEARCH_DEPTH: usize = 20;
 
 pub struct PathFinder<'a, StrategyDatabase>
-    where StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider {
+where
+    StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider,
+{
     evm: Option<PathFinderEvm<'a, StrategyDatabase>>,
     contract: Bytecode,
     liquidity_range: (U256, U256),
     profit_ratio_range: (U256, U256),
 }
 
-impl<'a, StrategyDatabase> Strategy<'a>
-    for PathFinder<'a, StrategyDatabase>
-    where StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider
+impl<'a, StrategyDatabase> Strategy<'a> for PathFinder<'a, StrategyDatabase>
+where
+    StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider,
 {
     type Action = Hop;
 
@@ -76,15 +87,17 @@ impl<'a, StrategyDatabase> Strategy<'a>
     }
 
     fn set_last_state(&mut self, provider: LatestStateProviderRef<'a, Self::DB>) {
-        let mut db: CacheDB<
-            StateProviderDatabase<LatestStateProviderRef<'a, StrategyDatabase>>
-        > = CacheDB::new(StateProviderDatabase::new(provider));
+        let mut db: CacheDB<StateProviderDatabase<LatestStateProviderRef<'a, StrategyDatabase>>> =
+            CacheDB::new(StateProviderDatabase::new(provider));
         let contract = self.contract.clone();
-        db.insert_account_info(STRATEGY_CONTRACT_ADDRESS, AccountInfo {
-            code_hash: contract.hash_slow(),
-            code: Some(contract.clone()),
-            ..Default::default()
-        });
+        db.insert_account_info(
+            STRATEGY_CONTRACT_ADDRESS,
+            AccountInfo {
+                code_hash: contract.hash_slow(),
+                code: Some(contract.clone()),
+                ..Default::default()
+            },
+        );
 
         let evm = Context::mainnet().with_db(db).build_mainnet();
 
@@ -98,7 +111,7 @@ impl<'a, StrategyDatabase> Strategy<'a>
     fn find_profitable_candidates<T: PoolTransaction>(
         &mut self,
         pending_txs: Vec<T>,
-        candidates: Vec<Candidate>
+        candidates: Vec<Candidate>,
     ) -> Result<Option<(Vec<u8>, AccessList)>, Error> {
         // 1. Get dirty states from pending transactions
         let evm = self.evm.as_mut().unwrap();
@@ -109,11 +122,13 @@ impl<'a, StrategyDatabase> Strategy<'a>
                 let to = tx.to()?;
                 let data = tx.input().clone();
                 let result = pevm.lock().unwrap().transact_system_call(data, to).unwrap();
-                let dirty_state: HashMap<Address, HashSet<U256>> = result.state
+                let dirty_state: HashMap<Address, HashSet<U256>> = result
+                    .state
                     .iter()
                     .filter(|(_, account)| account.is_touched())
                     .fold(HashMap::new(), |mut acc, (address, account)| {
-                        let changed_storage_keys: HashSet<U256> = account.storage
+                        let changed_storage_keys: HashSet<U256> = account
+                            .storage
                             .iter()
                             .filter(|(_, storage_slot)| storage_slot.is_changed())
                             .map(|(key, _)| *key)
@@ -144,7 +159,13 @@ impl<'a, StrategyDatabase> Strategy<'a>
             .take_any_while(|_| !found_max_profit.load(Ordering::Relaxed))
             .take_any(PROFITABLE_PATHS_LIMIT)
             .fold(
-                || (Vec::new(), HashMap::<Address, Vec<B256>>::new()),
+                || {
+                    (
+                        Vec::<U256>::new(),                   // amounts
+                        Vec::<Vec<Hop>>::new(),               // routes
+                        HashMap::<Address, Vec<B256>>::new(), // access lists
+                    )
+                },
                 |mut acc, candidate: &Candidate| {
                     if found_max_profit.load(Ordering::Relaxed) {
                         return acc;
@@ -160,6 +181,7 @@ impl<'a, StrategyDatabase> Strategy<'a>
                                 tracing::warn!(
                                     target: "reth-exex",
                                     action = "hop_decode_failed",
+                                    data = ?hop,
                                     "Failed to decode hop in candidate, skipping entire candidate"
                                 );
                                 return acc;
@@ -197,18 +219,16 @@ impl<'a, StrategyDatabase> Strategy<'a>
                         || Self::call_get_profit(&pevm, right, hops.clone()),
                     );
 
-                    let balance = if profit_left >= profit_right { left } else { right };
+                    let amount = if profit_left >= profit_right { left } else { right };
                     if found_max_profit.load(Ordering::Relaxed) {
                         return acc;
                     }
 
-                    let encoded_data = (getProfitCall {
-                        amount: balance,
-                        route: hops.clone(),
-                    }).abi_encode();
+                    let encoded_data = (getProfitCall { amount, route: hops.clone() }).abi_encode();
 
                     let element: Option<(Vec<Hop>, Vec<AccessListItem>)> = {
                         let mut evm = pevm.lock().unwrap();
+                        // TODO: access list from execute contract not from simulation contract
                         let ResultAndState { result, state } = evm
                             .transact_system_call(encoded_data.into(), STRATEGY_CONTRACT_ADDRESS)
                             .unwrap();
@@ -234,7 +254,7 @@ impl<'a, StrategyDatabase> Strategy<'a>
                             }
                         };
 
-                        let net_profit_ratio = net_profit.checked_div(balance).unwrap();
+                        let net_profit_ratio = net_profit.checked_div(amount).unwrap();
 
                         if net_profit_ratio.ge(&max_profit_ratio) {
                             found_max_profit.store(true, Ordering::Relaxed);
@@ -249,46 +269,48 @@ impl<'a, StrategyDatabase> Strategy<'a>
                     if element.is_none() {
                         return acc;
                     }
-                    let (profitable_paths, path_access_items) = element.unwrap();
+                    let (profitable_paths, access_items) = element.unwrap();
 
                     // accumulate results
-                    acc.0.push(profitable_paths);
-                    for item in path_access_items {
-                        if let Some(storage_keys) = acc.1.get_mut(&item.address) {
+                    acc.0.push(amount);
+                    acc.1.push(profitable_paths);
+                    for item in access_items {
+                        if let Some(storage_keys) = acc.2.get_mut(&item.address) {
                             storage_keys.extend(item.storage_keys);
                         } else {
-                            acc.1.insert(item.address, item.storage_keys);
+                            acc.2.insert(item.address, item.storage_keys);
                         }
                     }
 
                     acc
-                }
+                },
             )
             // Combine results from all threads
             .reduce_with(|mut acc, curr| {
                 acc.0.extend(curr.0);
-                for (address, storage_keys) in curr.1 {
-                    if let Some(existing_keys) = acc.1.get_mut(&address) {
+                acc.1.extend(curr.1);
+                for (address, storage_keys) in curr.2 {
+                    if let Some(existing_keys) = acc.2.get_mut(&address) {
                         existing_keys.extend(storage_keys);
                     } else {
-                        acc.1.insert(address, storage_keys);
+                        acc.2.insert(address, storage_keys);
                     }
                 }
 
                 acc
             })
             // Convert to the final result
-            .map(|(paths, access_map)| {
+            .map(|(amounts, routes, access_map)| {
                 let access_list = AccessList::from(
                     access_map
                         .into_iter()
                         .map(|(address, storage_keys)| AccessListItem { address, storage_keys })
-                        .collect::<Vec<AccessListItem>>()
+                        .collect::<Vec<AccessListItem>>(),
                 );
 
-                if !paths.is_empty() {
+                if !routes.is_empty() {
                     // Log the routes being sent
-                    let routes = paths
+                    let routes = routes
                         .clone()
                         .iter()
                         .map(|route| format!("{:?}", route))
@@ -301,8 +323,7 @@ impl<'a, StrategyDatabase> Strategy<'a>
                         routes = routes.join(", "),
                     );
                 }
-                // TODO(@junha-ahn): amounts should be passed as well
-                let calldata = (executeCall { amounts: todo!(), routes: paths }).abi_encode();
+                let calldata = (executeCall { amounts, routes }).abi_encode();
 
                 (calldata, access_list)
             });
@@ -316,22 +337,19 @@ where
     StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider,
 {
     fn call_get_profit(
-        pevm: &Arc<Mutex<PathFinderEvm<'a, StrategyDatabase>>>,
+        pevm: &Arc<Mutex<&mut PathFinderEvm<'a, StrategyDatabase>>>,
         amount: U256,
         route: Vec<Hop>,
     ) -> U256 {
         let encoded = (getProfitCall { amount, route }).abi_encode();
         let mut evm = pevm.lock().unwrap();
-        let ResultAndState { result, .. } = evm
-            .transact_system_call(encoded.into(), STRATEGY_CONTRACT_ADDRESS)
-            .unwrap();
+        let ResultAndState { result, .. } =
+            evm.transact_system_call(encoded.into(), STRATEGY_CONTRACT_ADDRESS).unwrap();
         match result {
-            ExecutionResult::Success {
-                output: Output::Call(value),
-                ..
-            } => <U256>::abi_decode(&value).unwrap_or_default(),
+            ExecutionResult::Success { output: Output::Call(value), .. } => {
+                <U256>::abi_decode(&value).unwrap_or_default()
+            }
             _ => U256::ZERO,
         }
     }
 }
-

--- a/crates/strategy/src/path_finding/path_finder.rs
+++ b/crates/strategy/src/path_finding/path_finder.rs
@@ -181,48 +181,8 @@ impl<'a, StrategyDatabase> Strategy<'a>
                         let mid2 = right - one_third;
 
                         let (profit1, profit2) = join(
-                            || {
-                                let encoded = (getProfitCall {
-                                    amount: mid1,
-                                    route: hops.clone(),
-                                })
-                                    .abi_encode();
-                                let mut evm = pevm.lock().unwrap();
-                                let ResultAndState { result, .. } = evm
-                                    .transact_system_call(
-                                        encoded.into(),
-                                        STRATEGY_CONTRACT_ADDRESS,
-                                    )
-                                    .unwrap();
-                                match result {
-                                    ExecutionResult::Success {
-                                        output: Output::Call(value),
-                                        ..
-                                    } => <U256>::abi_decode(&value).unwrap_or_default(),
-                                    _ => U256::ZERO,
-                                }
-                            },
-                            || {
-                                let encoded = (getProfitCall {
-                                    amount: mid2,
-                                    route: hops.clone(),
-                                })
-                                    .abi_encode();
-                                let mut evm = pevm.lock().unwrap();
-                                let ResultAndState { result, .. } = evm
-                                    .transact_system_call(
-                                        encoded.into(),
-                                        STRATEGY_CONTRACT_ADDRESS,
-                                    )
-                                    .unwrap();
-                                match result {
-                                    ExecutionResult::Success {
-                                        output: Output::Call(value),
-                                        ..
-                                    } => <U256>::abi_decode(&value).unwrap_or_default(),
-                                    _ => U256::ZERO,
-                                }
-                            },
+                            || Self::call_get_profit(&pevm, mid1, hops.clone()),
+                            || Self::call_get_profit(&pevm, mid2, hops.clone()),
                         );
 
                         if profit1 < profit2 {
@@ -233,48 +193,8 @@ impl<'a, StrategyDatabase> Strategy<'a>
                     }
 
                     let (profit_left, profit_right) = join(
-                        || {
-                            let encoded = (getProfitCall {
-                                amount: left,
-                                route: hops.clone(),
-                            })
-                                .abi_encode();
-                            let mut evm = pevm.lock().unwrap();
-                            let ResultAndState { result, .. } = evm
-                                .transact_system_call(
-                                    encoded.into(),
-                                    STRATEGY_CONTRACT_ADDRESS,
-                                )
-                                .unwrap();
-                            match result {
-                                ExecutionResult::Success {
-                                    output: Output::Call(value),
-                                    ..
-                                } => <U256>::abi_decode(&value).unwrap_or_default(),
-                                _ => U256::ZERO,
-                            }
-                        },
-                        || {
-                            let encoded = (getProfitCall {
-                                amount: right,
-                                route: hops.clone(),
-                            })
-                                .abi_encode();
-                            let mut evm = pevm.lock().unwrap();
-                            let ResultAndState { result, .. } = evm
-                                .transact_system_call(
-                                    encoded.into(),
-                                    STRATEGY_CONTRACT_ADDRESS,
-                                )
-                                .unwrap();
-                            match result {
-                                ExecutionResult::Success {
-                                    output: Output::Call(value),
-                                    ..
-                                } => <U256>::abi_decode(&value).unwrap_or_default(),
-                                _ => U256::ZERO,
-                            }
-                        },
+                        || Self::call_get_profit(&pevm, left, hops.clone()),
+                        || Self::call_get_profit(&pevm, right, hops.clone()),
                     );
 
                     let balance = if profit_left >= profit_right { left } else { right };
@@ -388,6 +308,30 @@ impl<'a, StrategyDatabase> Strategy<'a>
             });
 
         Ok(result)
+    }
+}
+
+impl<'a, StrategyDatabase> PathFinder<'a, StrategyDatabase>
+where
+    StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider,
+{
+    fn call_get_profit(
+        pevm: &Arc<Mutex<PathFinderEvm<'a, StrategyDatabase>>>,
+        amount: U256,
+        route: Vec<Hop>,
+    ) -> U256 {
+        let encoded = (getProfitCall { amount, route }).abi_encode();
+        let mut evm = pevm.lock().unwrap();
+        let ResultAndState { result, .. } = evm
+            .transact_system_call(encoded.into(), STRATEGY_CONTRACT_ADDRESS)
+            .unwrap();
+        match result {
+            ExecutionResult::Success {
+                output: Output::Call(value),
+                ..
+            } => <U256>::abi_decode(&value).unwrap_or_default(),
+            _ => U256::ZERO,
+        }
     }
 }
 

--- a/crates/strategy/src/path_finding/path_finder.rs
+++ b/crates/strategy/src/path_finding/path_finder.rs
@@ -4,7 +4,10 @@ use alloy_primitives::{ Address, B256, U256, map::HashSet };
 use alloy_rpc_types::{ AccessList, AccessListItem };
 use alloy_sol_types::{ SolCall, SolValue };
 use eyre::{ Error, Ok, Result };
-use rayon::iter::{ IntoParallelRefIterator, ParallelIterator };
+use rayon::{
+    iter::{ IntoParallelRefIterator, ParallelIterator },
+    join,
+};
 use reth_provider::{ BlockHashReader, DBProvider, LatestStateProviderRef, StateCommitmentProvider };
 use reth_revm::{
     Context,
@@ -42,6 +45,7 @@ type PathFinderEvm<'a, DB> = Evm<
 >;
 
 const PROFITABLE_PATHS_LIMIT: usize = 10;
+const MAX_SEARCH_DEPTH: usize = 20;
 
 pub struct PathFinder<'a, StrategyDatabase>
     where StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider {
@@ -132,7 +136,7 @@ impl<'a, StrategyDatabase> Strategy<'a>
 
         // 2. Filter candidates based on vault balances and profit ratios
         let (max_profit_ratio, min_profit_ratio) = self.profit_ratio_range;
-        let (max_liquidity, min_liquidity) = self.liquidity_range;
+        let (min_liquidity, max_liquidity) = self.liquidity_range;
         let found_max_profit = Arc::new(AtomicBool::new(false));
 
         let result = candidates
@@ -142,12 +146,6 @@ impl<'a, StrategyDatabase> Strategy<'a>
             .fold(
                 || (Vec::new(), HashMap::<Address, Vec<B256>>::new()),
                 |mut acc, candidate: &Candidate| {
-                    if found_max_profit.load(Ordering::Relaxed) {
-                        return acc;
-                    }
-                    // TODO(@junha-ahn): searching algorithm to get optimized balance range in
-                    // 0..max_liquidity
-                    let balance = todo!("Implement balance optimization logic");
                     if found_max_profit.load(Ordering::Relaxed) {
                         return acc;
                     }
@@ -169,9 +167,19 @@ impl<'a, StrategyDatabase> Strategy<'a>
                         }
                     }
 
+                    let balance = Self::search_optimal_balance(
+                        &pevm,
+                        &hops,
+                        min_liquidity,
+                        max_liquidity,
+                    );
+                    if found_max_profit.load(Ordering::Relaxed) {
+                        return acc;
+                    }
+
                     let encoded_data = (getProfitCall {
                         amount: balance,
-                        route: hops,
+                        route: hops.clone(),
                     }).abi_encode();
 
                     let element: Option<(Vec<Hop>, Vec<AccessListItem>)> = {
@@ -275,5 +283,65 @@ impl<'a, StrategyDatabase> Strategy<'a>
             });
 
         Ok(result)
+    }
+}
+
+impl<'a, StrategyDatabase> PathFinder<'a, StrategyDatabase>
+where
+    StrategyDatabase: DBProvider + BlockHashReader + StateCommitmentProvider,
+{
+    fn evaluate_profit(
+        pevm: &Arc<Mutex<PathFinderEvm<'a, StrategyDatabase>>>,
+        hops: &[Hop],
+        amount: U256,
+    ) -> U256 {
+        let encoded = (getProfitCall { amount, route: hops.to_vec() }).abi_encode();
+        let mut evm = pevm.lock().unwrap();
+        let ResultAndState { result, .. } = evm
+            .transact_system_call(encoded.into(), STRATEGY_CONTRACT_ADDRESS)
+            .unwrap();
+        match result {
+            ExecutionResult::Success { output: Output::Call(value), .. } => {
+                <U256>::abi_decode(&value).unwrap_or_default()
+            }
+            _ => U256::ZERO,
+        }
+    }
+
+    fn search_optimal_balance(
+        pevm: &Arc<Mutex<PathFinderEvm<'a, StrategyDatabase>>>,
+        hops: &[Hop],
+        min_liquidity: U256,
+        max_liquidity: U256,
+    ) -> U256 {
+        let mut left = min_liquidity;
+        let mut right = max_liquidity;
+
+        for _ in 0..MAX_SEARCH_DEPTH {
+            if right <= left + U256::from(1u8) {
+                break;
+            }
+
+            let diff = right - left;
+            let one_third = diff / U256::from(3u8);
+            let mid1 = left + one_third;
+            let mid2 = right - one_third;
+
+            let (profit1, profit2) = join(
+                || Self::evaluate_profit(pevm, hops, mid1),
+                || Self::evaluate_profit(pevm, hops, mid2),
+            );
+
+            if profit1 < profit2 {
+                left = mid1;
+            } else {
+                right = mid2;
+            }
+        }
+
+        let profit_left = Self::evaluate_profit(pevm, hops, left);
+        let profit_right = Self::evaluate_profit(pevm, hops, right);
+
+        if profit_left >= profit_right { left } else { right }
     }
 }


### PR DESCRIPTION
## Summary
- implement ternary search for optimal balance inside `PathFinder`
- add `MAX_SEARCH_DEPTH` constant
- decode candidate hops before optimization

## Testing
- `cargo test --quiet --offline` *(fails: failed to load source for dependency `reth`)*

------
https://chatgpt.com/codex/tasks/task_e_6866b745ceb4832684414da3e6d1456b