### PR TITLE
Improve signal manager and add crate overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Searcher Reth
+
+This repository contains a set of crates that build a searcher on top of the
+[Reth](https://github.com/paradigmxyz/reth) client.  Each crate has a focused
+responsibility which is summarized below.
+
+## Crates
+
+| Crate | Role |
+|-------|------|
+| **bin/searcher-reth** | Binary that launches Reth with the searcher extension installed. |
+| **crates/config** | Loading and managing configuration files and candidate data. |
+| **crates/core** | Fundamental traits and constants shared across strategies. |
+| **crates/strategy** | Implementation of searcher strategies (e.g. path finding). |
+| **crates/extension** | Glue code that runs inside Reth's ExEx framework and handles relaying transactions. |
+| **crates/util** | Utilities such as logging setup and signal handling. |
+
+## Flow
+
+```mermaid
+flowchart TD
+    subgraph Node
+        A[Reth Node]
+    end
+    B[SearcherExEx]
+    C[PathFinder]
+    D[RelayerPool]
+    E[ConfigManager]
+
+    A --> B
+    B -->|uses| E
+    B --> C
+    C -->|sends tx| D
+    D -->|broadcasts| A
+```
+
+The binary starts a Reth node and installs `SearcherExEx`. The extension loads
+configuration via `ConfigManager`, finds profitable routes with `PathFinder` and
+submits transactions through `RelayerPool`.

--- a/crates/util/src/signal_manager.rs
+++ b/crates/util/src/signal_manager.rs
@@ -34,6 +34,18 @@ impl SignalManager {
         self.signal_tx.subscribe()
     }
 
+    fn send_signal(&self, signal: SignalType) {
+        let _ = self.signal_tx.send(signal);
+    }
+
+    fn toggle_pause(&self, paused: &mut bool) {
+        *paused = !*paused;
+        let signal = if *paused { SignalType::Pause } else { SignalType::Resume };
+        let status = if *paused { "paused" } else { "running" };
+        self.send_signal(signal);
+        tracing::info!(event = "turn off/on", status = status);
+    }
+
     pub async fn start_signal_handling(&self) -> Result<(), eyre::Error> {
         let mut sigterm = signal(SignalKind::terminate())?;
         let mut sigint = signal(SignalKind::interrupt())?;
@@ -50,18 +62,10 @@ impl SignalManager {
         loop {
             tokio::select! {
                 _ = sigusr1.recv() => {
-                    is_paused = !is_paused;
-                    let signal_type = if is_paused { SignalType::Pause } else { SignalType::Resume };
-                    let status_str = if is_paused { "paused" } else { "running" };
-
-                    let _ = self.signal_tx.send(signal_type);
-                    tracing::info!(
-                        event = "turn off/on",
-                        status = status_str,
-                    );
+                    self.toggle_pause(&mut is_paused);
                 }
                 _ = sigusr2.recv() => {
-                    let _ = self.signal_tx.send(SignalType::Reload);
+                    self.send_signal(SignalType::Reload);
                     tracing::info!(
                         event = "reload",
                         status = "reloaded",


### PR DESCRIPTION
## Summary
- refactor `SignalManager` with helper functions for sending and toggling pause
- document crate responsibilities in the project `README`

## Testing
- `cargo fmt --all` *(failed: rustfmt component missing)*
- `cargo test --workspace --all-targets` *(failed to fetch dependencies: network blocked)*
- `cargo check --workspace` *(failed to fetch dependencies: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686750bdaea4832681edcdd048040390