### PR TITLE
Implement Telegram profit notifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,6 @@ toml = "0.8.22"
 #clap
 clap = "4.5.37"
 rayon = "1.10.0"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+once_cell = "1"

--- a/README.md
+++ b/README.md
@@ -35,3 +35,24 @@ flowchart TD
 The binary starts a Reth node and installs `SearcherExEx`. The extension loads
 configuration via `ConfigManager`, finds profitable routes with `PathFinder` and
 submits transactions through `RelayerPool`.
+
+## Telegram Notifications
+
+Profits detected by `PathFinder` are batched at a configurable interval (default
+10 minutes) and sent to a Telegram chat. To enable this feature:
+
+1. Create a Telegram bot using [@BotFather](https://t.me/BotFather) and obtain
+   the bot token.
+2. Determine the chat ID to which the bot should send messages. Sending a message
+   to the bot and calling `getUpdates` on the Bot API is one way to retrieve it.
+3. Add a `[telegram]` section to your `env.toml`:
+
+```toml
+[telegram]
+bot_token = "<your bot token>"
+chat_id = "<target chat id>"
+report_interval_secs = 600
+```
+
+When configured, each batch of profit information is also stored locally as
+`profits_TIMESTAMP.json`.

--- a/bin/searcher-reth/src/main.rs
+++ b/bin/searcher-reth/src/main.rs
@@ -7,13 +7,20 @@ use reth_tracing::tracing::{self, error};
 use searcher_reth_extension::{
     exex::SearcherExEx,
     relayer_pool::WalletPool,
-    strategy::{core::strategy::Strategy, path_finding::PathFinder},
+    strategy::{
+        core::strategy::Strategy,
+        path_finding::PathFinder,
+        profit_reporter::init_reporter,
+    },
     util::signal_manager::SignalManager,
 };
 use searcher_reth_manager::{SignalType, common::PATH_FINDER_EXEX_ID, manager::ConfigManager};
 
 fn main() -> eyre::Result<()> {
     let config = Arc::new(RwLock::new(ConfigManager::from_file("env.toml")?));
+    if let Some(tg) = config.read().unwrap().get_telegram() {
+        init_reporter(tg.bot_token, tg.chat_id, tg.report_interval_secs);
+    }
     let wallet = config.read().unwrap().get_wallet().unwrap();
     let wallet = Arc::new(WalletPool::new(wallet));
     tracing::info!("Starting searcher-reth with wallet: {:?}", wallet.signers());

--- a/crates/manager/src/manager.rs
+++ b/crates/manager/src/manager.rs
@@ -63,6 +63,8 @@ pub struct Config {
     pub relayer: TxRelayerConfig,
     #[serde(default, rename = "strategy")]
     pub strategies: HashMap<ExExId, StrategyConfig>,
+    #[serde(default)]
+    pub telegram: Option<TelegramConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,5 +87,24 @@ impl TxRelayerConfig {
             addresses.push(signer.address());
         }
         Ok((wallet, addresses))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TelegramConfig {
+    pub bot_token: String,
+    pub chat_id: String,
+    #[serde(default = "default_report_interval_secs")]
+    pub report_interval_secs: u64,
+}
+
+fn default_report_interval_secs() -> u64 {
+    600
+}
+
+impl ConfigManager {
+    pub fn get_telegram(&self) -> Option<TelegramConfig> {
+        self.config.read().unwrap().telegram.clone()
     }
 }

--- a/crates/strategy/Cargo.toml
+++ b/crates/strategy/Cargo.toml
@@ -45,3 +45,6 @@ reth-transaction-pool.workspace = true
 searcher-reth-manager.workspace = true
 
 serde_json.workspace = true
+reqwest.workspace = true
+chrono.workspace = true
+once_cell.workspace = true

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod core;
 pub mod path_finding;
+pub mod profit_reporter;

--- a/crates/strategy/src/path_finding/path_finder.rs
+++ b/crates/strategy/src/path_finding/path_finder.rs
@@ -18,9 +18,9 @@ use searcher_reth_manager::{
 
 use crate::path_finding::types::executeCall;
 
-use super::types::{ Hop, getProfitCall };
+use super::types::{getProfitCall, Hop};
+use crate::profit_reporter::record_profit;
 use serde_json;
-use std::{ fs::OpenOptions, io::Write };
 
 const PROFITABLE_PATHS_LIMIT: usize = 10;
 const MAX_SEARCH_DEPTH: usize = 20;
@@ -188,21 +188,12 @@ impl Strategy for PathFinder {
                         return acc;
                     };
 
-                    // FIXME: (temp) Log profit information to a file
-                    let profit_info =
-                        serde_json::json!({
+                    let profit_info = serde_json::json!({
                         "amount": amount.to_string(),
                         "profit": profit.to_string(),
                         "route": route.iter().map(|hop| format!("{:?}", hop)).collect::<Vec<_>>(),
                     });
-                    if
-                        let std::result::Result::Ok(mut file) = OpenOptions::new()
-                            .create(true)
-                            .append(true)
-                            .open("profits.json")
-                    {
-                        let _ = writeln!(file, "{}", profit_info);
-                    }
+                    record_profit(profit_info);
 
                     tracing::info!(
                         target: "path-finder",

--- a/crates/strategy/src/profit_reporter.rs
+++ b/crates/strategy/src/profit_reporter.rs
@@ -1,0 +1,80 @@
+use std::{fs::File, io::Write, sync::{Arc, Mutex}};
+
+use chrono::Utc;
+use reqwest::Client;
+use serde_json::Value;
+use tokio::{spawn, time::{interval, Duration}};
+
+#[derive(Clone)]
+pub struct ProfitReporter {
+    buffer: Arc<Mutex<Vec<Value>>>,
+    token: String,
+    chat_id: String,
+    interval_secs: u64,
+}
+
+impl ProfitReporter {
+    pub fn new(token: String, chat_id: String, interval_secs: u64) -> Self {
+        let reporter = Self {
+            buffer: Arc::new(Mutex::new(Vec::new())),
+            token,
+            chat_id,
+            interval_secs,
+        };
+        reporter.spawn_task();
+        reporter
+    }
+
+    pub fn record(&self, info: Value) {
+        let mut buf = self.buffer.lock().unwrap();
+        buf.push(info);
+    }
+
+    fn spawn_task(&self) {
+        let buffer = self.buffer.clone();
+        let token = self.token.clone();
+        let chat_id = self.chat_id.clone();
+        let interval_secs = self.interval_secs;
+        spawn(async move {
+            let client = Client::new();
+            let mut timer = interval(Duration::from_secs(interval_secs));
+            loop {
+                timer.tick().await;
+                let mut data = buffer.lock().unwrap();
+                if data.is_empty() {
+                    continue;
+                }
+                let timestamp = Utc::now().format("%Y%m%d_%H%M%S");
+                let filename = format!("profits_{}.json", timestamp);
+                if let Ok(mut file) = File::create(&filename) {
+                    for entry in data.iter() {
+                        let _ = writeln!(file, "{}", entry);
+                    }
+                }
+                let text = data.iter().map(|v| v.to_string()).collect::<Vec<_>>().join("\n");
+                let url = format!("https://api.telegram.org/bot{}/sendMessage", token);
+                let _ = client
+                    .post(url)
+                    .json(&serde_json::json!({"chat_id": chat_id, "text": text}))
+                    .send()
+                    .await;
+                data.clear();
+            }
+        });
+    }
+}
+
+use once_cell::sync::OnceLock;
+
+static REPORTER: OnceLock<ProfitReporter> = OnceLock::new();
+
+pub fn init_reporter(token: String, chat_id: String, interval: u64) {
+    REPORTER.get_or_init(|| ProfitReporter::new(token, chat_id, interval));
+}
+
+pub fn record_profit(info: Value) {
+    if let Some(r) = REPORTER.get() {
+        r.record(info);
+    }
+}
+

--- a/env.sample.toml
+++ b/env.sample.toml
@@ -11,3 +11,8 @@ min-liquidity = "100"
 max-profit-ratio = 0.005
 min-profit-ratio = 0.001
 data="./data.sample.json"
+
+[telegram]
+bot_token="YOUR_TELEGRAM_BOT_TOKEN"
+chat_id="YOUR_CHAT_ID"
+report_interval_secs=600


### PR DESCRIPTION
## Summary
- add ProfitReporter module and record profits
- send profit batches every 10 minutes through Telegram
- wire Telegram config into ConfigManager and main
- document Telegram setup in README
- update sample config
- make telegram report interval configurable

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' is not installed)*
- `cargo test --quiet` *(fails to fetch dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6874a451900483268868960155b0e0cc