### PR TITLE
Fix WAL warnings by reducing I/O blocking

### DIFF
--- a/bin/searcher-reth/src/main.rs
+++ b/bin/searcher-reth/src/main.rs
@@ -16,14 +16,15 @@ use searcher_reth_manager::{SignalType, common::PATH_FINDER_EXEX_ID, manager::Co
 
 fn main() -> eyre::Result<()> {
     let config = Arc::new(RwLock::new(ConfigManager::from_file("env.toml")?));
-    if let Some(tg) = config.read().unwrap().get_telegram() {
-        init_reporter(tg.bot_token, tg.chat_id, tg.report_interval_secs);
-    }
+    let telegram_cfg = config.read().unwrap().get_telegram();
     let wallet = config.read().unwrap().get_wallet().unwrap();
     let wallet = Arc::new(WalletPool::new(wallet));
     tracing::info!("Starting searcher-reth with wallet: {:?}", wallet.signers());
 
     reth::cli::Cli::<EthereumChainSpecParser>::parse().run(|builder, _| async move {
+        if let Some(tg) = telegram_cfg {
+            init_reporter(tg.bot_token, tg.chat_id, tg.report_interval_secs);
+        }
         // Spawn signal manager to handle signals
         let signal_manager = SignalManager::new();
         let spawned_signal_manager = signal_manager.clone();

--- a/crates/strategy/src/profit_reporter.rs
+++ b/crates/strategy/src/profit_reporter.rs
@@ -1,8 +1,7 @@
-use std::{
-    fs::File,
-    io::Write,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
+
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
 
 use chrono::Utc;
 use reqwest::Client;
@@ -53,9 +52,12 @@ impl ProfitReporter {
 
                 let timestamp = Utc::now().format("%Y%m%d_%H%M%S");
                 let filename = format!("profits_{}.json", timestamp);
-                if let Ok(mut file) = File::create(&filename) {
+                if let Ok(mut file) = tokio::fs::File::create(&filename).await {
                     for entry in data_to_process.iter() {
-                        let _ = writeln!(file, "{}", entry);
+                        let _ = file
+                            .write_all(entry.to_string().as_bytes())
+                            .await;
+                        let _ = file.write_all(b"\n").await;
                     }
                 }
                 let text =


### PR DESCRIPTION
## Summary
- use async file APIs in profit reporter to avoid blocking the runtime
- initialize the profit reporter only once the tokio runtime is running

## Testing
- `cargo check` *(fails: failed to fetch git dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6874bf5c1ca883268d318414e63e9be0